### PR TITLE
feat(login): added `otp` and `autoFocus` props to `PinInput`

### DIFF
--- a/apps/client/src/pages/Login/VerifyPincodeStep.tsx
+++ b/apps/client/src/pages/Login/VerifyPincodeStep.tsx
@@ -60,6 +60,8 @@ export const VerifyPincodeStep = ({ goBack, phoneNumber, onPincodeSuccess }: Ver
           </Text>
         </VStack>
         <PinInput.Root
+          otp
+          autoFocus
           value={pincode}
           onValueChange={(e) => setPincode(e.value)}
           size="2xl"


### PR DESCRIPTION
https://chakra-ui.com/docs/components/pin-input

And from JSDoc on `otp`: If true, the pin input component signals to its fields that they should use autocomplete="one-time-code".


