### PR TITLE
feat: hide edit-apartment fields from create-apartment

### DIFF
--- a/apps/client/src/i18n/locales/he.json
+++ b/apps/client/src/i18n/locales/he.json
@@ -76,7 +76,8 @@
                 "renter_pays": "אני משלם את ועד הבית",
                 "renters_paying_equally": "מתחלקים שווה בשווה",
                 "paying_for_renter": "מישהו אחר משלם את וועד הבית"
-            }
+            },
+            "on_create_notice": "לאחר יצירת הדירה וצירוף השותפים תוכלו להגדיר מי משלם על מה ועל מי (שכר דירה, וועד בית וכו')."
         },
         "share_apartment": {
             "title": "הדירה נוצרה בהצלחה! 🎉",

--- a/apps/client/src/pages/CreateApartment/CreateApartment.tsx
+++ b/apps/client/src/pages/CreateApartment/CreateApartment.tsx
@@ -6,7 +6,7 @@ import { ApartmentSettings } from './ApartmentSettings';
 import ShareApartmentCode from './ShareApartmentCode';
 import ApartmentLayout from './ApartmentLayout';
 import { ApartmentInfo } from './ApartmentInfo';
-import RenterSettings from './RenterSettings';
+import { RenterSettings } from './RenterSettings';
 import { CreateApartmentDto, UserRole, type CreateApartmentHttpResponse } from '@komuna/types';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';

--- a/apps/client/src/pages/CreateApartment/CreateApartment.tsx
+++ b/apps/client/src/pages/CreateApartment/CreateApartment.tsx
@@ -25,6 +25,7 @@ interface CreateApartmentFormProps {
   page: CreateApartmentPages;
   aptDetails: CreateApartmentDto;
   setPageState: UpdateFieldOfPageFn;
+  isEdit: boolean;
 }
 
 const INITIAL_APT_DETAILS: CreateApartmentDto = {
@@ -53,7 +54,7 @@ const INITIAL_APT_DETAILS: CreateApartmentDto = {
   },
 }
 
-const CreateApartmentForm: FC<CreateApartmentFormProps> = ({ page, aptDetails, setPageState }) => {
+const CreateApartmentForm: FC<CreateApartmentFormProps> = ({ page, aptDetails, setPageState, isEdit }) => {
   switch (page) {
     case CreateApartmentPages.ApartmentInfo:
       return <ApartmentInfo
@@ -69,6 +70,7 @@ const CreateApartmentForm: FC<CreateApartmentFormProps> = ({ page, aptDetails, s
       return <RenterSettings
         aptDetails={aptDetails}
         updateField={setPageState("renterSettings")}
+        isEdit={isEdit}
       />;
     case CreateApartmentPages.ShareApartmentCode:
       return <ShareApartmentCode />;
@@ -80,11 +82,14 @@ const CreateApartmentForm: FC<CreateApartmentFormProps> = ({ page, aptDetails, s
 };
 
 
+interface CreateApartmentProps {
+  isEdit?: boolean;
+}
 /**
 * Wraps the CreateApartmentForm in a layout with a back button.
 */
-const CreateApartment = () => {
-  const [page, setPage] = useState<CreateApartmentPages>(CreateApartmentPages.ApartmentInfo);
+const CreateApartment: FC<CreateApartmentProps> = ({ isEdit }) => {
+  const [page, setPage] = useState<CreateApartmentPages>(CreateApartmentPages.RenterSettings);
   const [aptDetails, setsAptDetails] = useState<CreateApartmentDto>(INITIAL_APT_DETAILS);
 
   const incPage = () => { setPage(p => p + 1); }
@@ -148,11 +153,13 @@ const CreateApartment = () => {
 
   return (
     <ApartmentLayout
-      goBack={page !== CreateApartmentPages.ShareApartmentCode && (() => goPageBack(page))}>
+      goBack={page !== CreateApartmentPages.ShareApartmentCode && (() => goPageBack(page))}
+    >
       <CreateApartmentForm
         page={page}
         aptDetails={aptDetails}
         setPageState={updateFieldOfPage}
+        isEdit={isEdit || false}
       />
       <HStack gap="30px">
         {showSkipBtn && <Button
@@ -176,7 +183,7 @@ const CreateApartment = () => {
             : t('create_apartment.continue_btn')}
         </Button>}
       </HStack>
-    </ApartmentLayout >
+    </ApartmentLayout>
   );
 };
 

--- a/apps/client/src/pages/CreateApartment/RenterSettings.tsx
+++ b/apps/client/src/pages/CreateApartment/RenterSettings.tsx
@@ -7,94 +7,94 @@ import { IconCurrencyShekel } from "@tabler/icons-react";
 import type { CommonApartmentProps } from "./create-apartment.types";
 
 export const RenterSettings = ({ aptDetails, updateField }: CommonApartmentProps<"renterSettings">) => {
-  const { t } = useTranslation();
+    const { t } = useTranslation();
 
-  const fields = useMemo(() => [
-    {
-      key: "rent",
-      title: t("create_apartment.renter_settings.renter_rent_price"),
-      optionTitle: t("create_apartment.renter_settings.renter_payment_ways.title"),
-      optionsKey: "payableByUserId",
-      options: [
-        { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_payment_ways.renter_pays"), },
-        { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_payment_ways.paying_for_renter"), input: true, },
-      ],
-    },
-    {
-      key: "houseCommitteeRent",
-      title: t("create_apartment.renter_settings.house_maintenance_fee"),
-      optionTitle: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.title"),
-      optionsKey: "houseCommitteePayerUserId",
-      options: [
-        { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renter_pays"), },
-        { value: RENTER_PAYMENT_WAYS.EQUALLY, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renters_paying_equally"), },
-        { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.paying_for_renter"), input: true, },
-      ],
-    },
-  ] as const, [t]);
+    const fields = useMemo(() => [
+        {
+            key: "rent",
+            title: t("create_apartment.renter_settings.renter_rent_price"),
+            optionTitle: t("create_apartment.renter_settings.renter_payment_ways.title"),
+            optionsKey: "payableByUserId",
+            options: [
+                { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_payment_ways.renter_pays"), },
+                { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_payment_ways.paying_for_renter"), input: true, },
+            ],
+        },
+        {
+            key: "houseCommitteeRent",
+            title: t("create_apartment.renter_settings.house_maintenance_fee"),
+            optionTitle: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.title"),
+            optionsKey: "houseCommitteePayerUserId",
+            options: [
+                { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renter_pays"), },
+                { value: RENTER_PAYMENT_WAYS.EQUALLY, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renters_paying_equally"), },
+                { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.paying_for_renter"), input: true, },
+            ],
+        },
+    ] as const, [t]);
 
 
-  return (
-    <Stack width="100%" gap="5">
-        <ApartmentTitle
-          title={t('create_apartment.renter_settings.title')}
-        />
-        {fields.map((field) => (
-          <>
-            <Field.Root>
-              <HStack justify="space-between">
-                <Field.Label fontWeight="bold" fontSize="md" w="70%">
-                  {field.title}
-                </Field.Label>
-                <InputGroup endElement={<IconCurrencyShekel />}>
-                  <Input
-                    value={aptDetails.renterSettings[field.key as keyof RenterSettingsDto]}
-                    onChange={(e) => updateField(field.key, e.target.value)}
-                    backgroundColor="white"
-                    size="xl"
-                    fontSize="xl"
-                  />
-                </InputGroup>
-              </HStack>
-            </Field.Root>
+    return (
+        <Stack width="100%" gap="5">
+            <ApartmentTitle
+                title={t('create_apartment.renter_settings.title')}
+            />
+            {fields.map((field) => (
+                <>
+                    <Field.Root>
+                        <HStack justify="space-between">
+                            <Field.Label fontWeight="bold" fontSize="md" w="70%">
+                                {field.title}
+                            </Field.Label>
+                            <InputGroup endElement={<IconCurrencyShekel />}>
+                                <Input
+                                    value={aptDetails.renterSettings[field.key as keyof RenterSettingsDto]}
+                                    onChange={(e) => updateField(field.key, e.target.value)}
+                                    backgroundColor="white"
+                                    size="xl"
+                                    fontSize="xl"
+                                />
+                            </InputGroup>
+                        </HStack>
+                    </Field.Root>
 
-            <RadioCard.Root
-              orientation="horizontal"
-              variant="subtle"
-              defaultValue={field.options[0].value}
-              onValueChange={({ value }) => updateField(field.optionsKey, value)}
-            >
-              <RadioCard.Label fontWeight="bold" fontSize="md">
-                {field.optionTitle}
-              </RadioCard.Label>
-              {field.options.map((option) => (
-                <RadioCard.Item
-                  key={option.value}
-                  value={option.value}
-                  backgroundColor="transparent"
-                >
-                  <RadioCard.ItemHiddenInput />
-                  <RadioCard.ItemControl backgroundColor="transparent">
-                    <RadioCard.ItemIndicator />
-                    <VStack align="left">
-                      <RadioCard.ItemText>
-                        {option.title}
-                      </RadioCard.ItemText>
-                      {"input" in option && option.input ?
-                        <Input
-                          // onChange={(e) => option.onChange(e.target.value)}
-                          backgroundColor="white"
-                          w="150%"
-                        /> : null}
-                    </VStack>
-                  </RadioCard.ItemControl>
-                </RadioCard.Item>
-              ))}
-            </RadioCard.Root >
-          </>
-        ))}
-      </Stack >
-  );
+                    <RadioCard.Root
+                        orientation="horizontal"
+                        variant="subtle"
+                        defaultValue={field.options[0].value}
+                        onValueChange={({ value }) => updateField(field.optionsKey, value)}
+                    >
+                        <RadioCard.Label fontWeight="bold" fontSize="md">
+                            {field.optionTitle}
+                        </RadioCard.Label>
+                        {field.options.map((option) => (
+                            <RadioCard.Item key={option.value}
+                                value={option.value}
+                                backgroundColor="transparent"
+                            >
+                                <RadioCard.ItemHiddenInput />
+                                <RadioCard.ItemControl backgroundColor="transparent">
+                                    <RadioCard.ItemIndicator />
+                                    <VStack align="left">
+                                        <RadioCard.ItemText>
+                                            {option.title}
+                                        </RadioCard.ItemText>
+                                        {"input" in option && option.input ?
+                                            <Input
+                                                // onChange={(e) => option.onChange(e.target.value)}
+                                                backgroundColor="white"
+                                                w="150%"
+                                            /> : null}
+                                    </VStack>
+                                </RadioCard.ItemControl>
+                            </RadioCard.Item>
+                        ))}
+                    </RadioCard.Root >
+                </>
+            ))
+            }
+        </Stack >
+    );
 }
 
 export default RenterSettings;

--- a/apps/client/src/pages/CreateApartment/RenterSettings.tsx
+++ b/apps/client/src/pages/CreateApartment/RenterSettings.tsx
@@ -114,5 +114,3 @@ export const RenterSettings = ({ aptDetails, updateField, isEdit }: (CommonApart
         </>
     );
 }
-
-export default RenterSettings;

--- a/apps/client/src/pages/CreateApartment/RenterSettings.tsx
+++ b/apps/client/src/pages/CreateApartment/RenterSettings.tsx
@@ -1,99 +1,117 @@
-import { useMemo } from "react";
-import { Field, HStack, Input, Stack, RadioCard, InputGroup, VStack } from "@chakra-ui/react";
+import { Fragment, useMemo } from "react";
+import { Field, HStack, Input, Stack, RadioCard, InputGroup, VStack, Alert } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { RenterSettingsDto, RENTER_PAYMENT_WAYS } from "@komuna/types";
 import { ApartmentTitle } from "./ApartmentTitle";
 import { IconCurrencyShekel } from "@tabler/icons-react";
 import type { CommonApartmentProps } from "./create-apartment.types";
 
-export const RenterSettings = ({ aptDetails, updateField }: CommonApartmentProps<"renterSettings">) => {
+export const RenterSettings = ({ aptDetails, updateField, isEdit }: (CommonApartmentProps<"renterSettings"> & { isEdit: boolean })) => {
     const { t } = useTranslation();
 
-    const fields = useMemo(() => [
-        {
-            key: "rent",
-            title: t("create_apartment.renter_settings.renter_rent_price"),
-            optionTitle: t("create_apartment.renter_settings.renter_payment_ways.title"),
-            optionsKey: "payableByUserId",
-            options: [
-                { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_payment_ways.renter_pays"), },
-                { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_payment_ways.paying_for_renter"), input: true, },
-            ],
-        },
-        {
-            key: "houseCommitteeRent",
-            title: t("create_apartment.renter_settings.house_maintenance_fee"),
-            optionTitle: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.title"),
-            optionsKey: "houseCommitteePayerUserId",
-            options: [
-                { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renter_pays"), },
-                { value: RENTER_PAYMENT_WAYS.EQUALLY, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renters_paying_equally"), },
-                { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.paying_for_renter"), input: true, },
-            ],
-        },
-    ] as const, [t]);
+    const fields = useMemo(() => {
+        const fields = [
+            {
+                key: "rent" as const,
+                title: t("create_apartment.renter_settings.renter_rent_price"),
+                optionTitle: t("create_apartment.renter_settings.renter_payment_ways.title"),
+                optionsKey: "payableByUserId" as const,
+                options: [
+                    { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_payment_ways.renter_pays"), },
+                    { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_payment_ways.paying_for_renter"), input: true, },
+                ],
+            },
+            {
+                key: "houseCommitteeRent" as const,
+                title: t("create_apartment.renter_settings.house_maintenance_fee"),
+                optionTitle: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.title"),
+                optionsKey: "houseCommitteePayerUserId" as const,
+                options: [
+                    { value: RENTER_PAYMENT_WAYS.RENTER, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renter_pays"), },
+                    { value: RENTER_PAYMENT_WAYS.EQUALLY, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.renters_paying_equally"), },
+                    { value: RENTER_PAYMENT_WAYS.ELSE, title: t("create_apartment.renter_settings.renter_house_maintenance_payment_ways.paying_for_renter"), input: true, },
+                ],
+            },
+        ];
+        if (!isEdit) {
+            fields[0].options = [];
+            fields[1].options.pop();
+        }
+        return fields;
+    }, [t, isEdit]);
 
 
     return (
-        <Stack width="100%" gap="5">
-            <ApartmentTitle
-                title={t('create_apartment.renter_settings.title')}
-            />
-            {fields.map((field) => (
-                <>
-                    <Field.Root>
-                        <HStack justify="space-between">
-                            <Field.Label fontWeight="bold" fontSize="md" w="70%">
-                                {field.title}
-                            </Field.Label>
-                            <InputGroup endElement={<IconCurrencyShekel />}>
-                                <Input
-                                    value={aptDetails.renterSettings[field.key as keyof RenterSettingsDto]}
-                                    onChange={(e) => updateField(field.key, e.target.value)}
-                                    backgroundColor="white"
-                                    size="xl"
-                                    fontSize="xl"
-                                />
-                            </InputGroup>
-                        </HStack>
-                    </Field.Root>
+        <>
+            <Stack width="100%" gap="5" flexGrow={1}>
+                <ApartmentTitle
+                    title={t('create_apartment.renter_settings.title')}
+                />
+                {fields.map((field) => (
+                    <Fragment key={field.key}>
+                        <Field.Root>
+                            <HStack justify="space-between">
+                                <Field.Label fontWeight="bold" fontSize="md" w="70%">
+                                    {field.title}
+                                </Field.Label>
+                                <InputGroup endElement={<IconCurrencyShekel />}>
+                                    <Input
+                                        value={aptDetails.renterSettings[field.key as keyof RenterSettingsDto]}
+                                        onChange={(e) => updateField(field.key, e.target.value)}
+                                        backgroundColor="white"
+                                        size="xl"
+                                        fontSize="xl"
+                                    />
+                                </InputGroup>
+                            </HStack>
+                        </Field.Root>
 
-                    <RadioCard.Root
-                        orientation="horizontal"
-                        variant="subtle"
-                        defaultValue={field.options[0].value}
-                        onValueChange={({ value }) => updateField(field.optionsKey, value)}
-                    >
-                        <RadioCard.Label fontWeight="bold" fontSize="md">
-                            {field.optionTitle}
-                        </RadioCard.Label>
-                        {field.options.map((option) => (
-                            <RadioCard.Item key={option.value}
-                                value={option.value}
-                                backgroundColor="transparent"
+                        {field.options.length === 0 ? null : (
+                            <RadioCard.Root
+                                orientation="horizontal"
+                                variant="subtle"
+                                defaultValue={field.options[0].value}
+                                onValueChange={({ value }) => updateField(field.optionsKey, value)}
                             >
-                                <RadioCard.ItemHiddenInput />
-                                <RadioCard.ItemControl backgroundColor="transparent">
-                                    <RadioCard.ItemIndicator />
-                                    <VStack align="left">
-                                        <RadioCard.ItemText>
-                                            {option.title}
-                                        </RadioCard.ItemText>
-                                        {"input" in option && option.input ?
-                                            <Input
-                                                // onChange={(e) => option.onChange(e.target.value)}
-                                                backgroundColor="white"
-                                                w="150%"
-                                            /> : null}
-                                    </VStack>
-                                </RadioCard.ItemControl>
-                            </RadioCard.Item>
-                        ))}
-                    </RadioCard.Root >
-                </>
-            ))
-            }
-        </Stack >
+                                <RadioCard.Label fontWeight="bold" fontSize="md">
+                                    {field.optionTitle}
+                                </RadioCard.Label>
+                                {field.options.map((option) => (
+                                    <RadioCard.Item key={option.value}
+                                        value={option.value}
+                                        backgroundColor="transparent"
+                                    >
+                                        <RadioCard.ItemHiddenInput />
+                                        <RadioCard.ItemControl backgroundColor="transparent">
+                                            <RadioCard.ItemIndicator />
+                                            <VStack align="left">
+                                                <RadioCard.ItemText>
+                                                    {option.title}
+                                                </RadioCard.ItemText>
+                                                {"input" in option && option.input ?
+                                                    <Input
+                                                        // onChange={(e) => option.onChange(e.target.value)}
+                                                        backgroundColor="white"
+                                                        w="150%"
+                                                    /> : null}
+                                            </VStack>
+                                        </RadioCard.ItemControl>
+                                    </RadioCard.Item>
+                                ))}
+                            </RadioCard.Root >
+                        )}
+                    </Fragment>
+                ))}
+
+            </Stack >
+
+            {isEdit ? null : (
+                <Alert.Root status="info">
+                    <Alert.Indicator />
+                    <Alert.Title>{t("create_apartment.renter_settings.on_create_notice")}</Alert.Title>
+                </Alert.Root>
+            )}
+        </>
     );
 }
 

--- a/apps/client/src/pages/EditApartment/EditApartment.tsx
+++ b/apps/client/src/pages/EditApartment/EditApartment.tsx
@@ -1,0 +1,5 @@
+import CreateApartment from "../CreateApartment/CreateApartment"
+
+export const EditApartment = () => {
+  return <CreateApartment isEdit={true} />
+}

--- a/apps/client/src/routes/edit-apartment.tsx
+++ b/apps/client/src/routes/edit-apartment.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { EditApartment } from '../pages/EditApartment/EditApartment';
+
+export const Route = createFileRoute('/edit-apartment')({
+  beforeLoad: ({ context }) => {
+    if (!context.currentUserDetails) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: () => <EditApartment />,
+});


### PR DESCRIPTION
On create-apartment there should be no selection fields of apartment residents.

### Create apartment
![image](https://github.com/user-attachments/assets/f9088004-fa1a-4ded-bcb6-1b9003ac703e)
(Previously was identical to Edit apartment below)
### Edit apartment
![image](https://github.com/user-attachments/assets/f0938b13-cbcf-41ba-a407-adf0089f1fc4)
