### PR TITLE
fix(create-apartment): if landlord then no landlord-code

### DIFF
--- a/apps/client/src/pages/CreateApartment/ShareApartmentCode.tsx
+++ b/apps/client/src/pages/CreateApartment/ShareApartmentCode.tsx
@@ -36,19 +36,22 @@ const Codes: FC = () => {
     filters: { status: "success", mutationKey: ["createApartment"], },
   });
 
-  const getValidCode = (code?: CodeType): string => {
+  const getValidCode = (code?: CodeType, allowNull = false): string | null => {
     if (typeof code === "string") {
       return code;
     }
     else if (typeof code === "number") {
       return code.toString();
     }
+    else if (allowNull && code == null) {
+      return null;
+    }
     throw new Error("Invalid code type");
   }
 
   try {
     const roommateCode = getValidCode(mutationState.data?.roommateCode);
-    const landlordCode = getValidCode(mutationState.data?.landlordCode);
+    const landlordCode = getValidCode(mutationState.data?.landlordCode, true);
 
     return (
       <>
@@ -68,7 +71,8 @@ const Codes: FC = () => {
 
 }
 
-const Code: FC<{ code: string, description: string }> = ({ code, description }) => {
+const Code: FC<{ code: string | null, description: string }> = ({ code, description }) => {
+  if (!code) { return null; }
   return (
     <VStack borderRadius='lg'>
       <Text fontSize="lg" textAlign="center" >

--- a/apps/server/src/apartment/apartment.controller.ts
+++ b/apps/server/src/apartment/apartment.controller.ts
@@ -32,9 +32,10 @@ export class ApartmentController {
       createApartmentData,
       user
     );
+    const isLandlord = createApartmentData.apartmentInfo.role === UserRole.LANDLORD;
 
-    const landlordCode = generateApartmentCode(ApartmentController.CODE_LENGTH);
     const roommateCode = generateApartmentCode(ApartmentController.CODE_LENGTH);
+    const landlordCode = isLandlord ? null : generateApartmentCode(ApartmentController.CODE_LENGTH);
 
     const apartment = new Apartment();
     apartment.name = createApartmentData.apartmentInfo.name;
@@ -49,7 +50,6 @@ export class ApartmentController {
     apartment.landlordCode = landlordCode;
     apartment.roommateCode = roommateCode;
 
-    const isLandlord = createApartmentData.apartmentInfo.role === UserRole.LANDLORD;
     if (isLandlord) {
       const landlordUser = new User();
       landlordUser.userId = user.userId;


### PR DESCRIPTION
Before, if an aparment was created by a user who selected he's a landlord -- it would still generate a landlord code and show it on the share-code page.

Now, it doesn't generate a landlord code neither does it show a landlord code on the page (it shows only the roommate code)
